### PR TITLE
ci: publish to Cocoapods when release PR is merged

### DIFF
--- a/.github/workflows/publish_cocoapods.yml
+++ b/.github/workflows/publish_cocoapods.yml
@@ -1,0 +1,23 @@
+name: Publish Cocoapods
+
+on:
+  pull_request:
+    types: 
+      - closed
+    branches:
+      - 'main'
+
+jobs:
+  publish_cocoapods:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+    runs-on: macos-12
+    steps:
+    - name: Repository checkout
+      uses: actions/checkout@v3
+    - name: Deploy to Cocoapods
+      run: |
+        set -eo pipefail
+        pod lib lint --allow-warnings --verbose
+        pod trunk push --allow-warnings --verbose
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
A release tag must be created before the Cocoapods publishing happens since the XCTFramework file needs to be uploaded to the release tag, and the generated link used in the .podspec file to make the binary available on cocoapods.

In order to automate the process, knowing that the tag is created first, this repository will rely on a `release/<version>` branch being merged into `main` to trigger the automation.